### PR TITLE
Changed not to split escaped colons

### DIFF
--- a/naming.go
+++ b/naming.go
@@ -37,6 +37,8 @@ func NewItem() *Item {
 	}
 }
 
+var goCpeOriginalDelim = "[goCpeOriginalDelim]"
+
 func NewItemFromWfn(wfn string) (*Item, error) {
 	if strings.HasPrefix(wfn, "wfn:[") {
 		wfn = strings.TrimPrefix(wfn, "wfn:[")
@@ -127,7 +129,7 @@ func NewItemFromUri(uri string) (*Item, error) {
 
 func NewItemFromFormattedString(str string) (*Item, error) {
 	if strings.HasPrefix(str, "cpe:2.3:") {
-		str = strings.TrimPrefix(str, "cpe:2.3:")
+		str = replaceToDelim(strings.TrimPrefix(str, "cpe:2.3:"))
 	} else {
 		return nil, cpeerr{reason: err_invalid_wfn}
 	}
@@ -141,27 +143,27 @@ func NewItemFromFormattedString(str string) (*Item, error) {
 	for i, attr := range attrs {
 		switch i {
 		case 0:
-			item.part = newPartAttrFromFmtEncoded(attr)
+			item.part = newPartAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 1:
-			item.vendor = newStringAttrFromFmtEncoded(attr)
+			item.vendor = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 2:
-			item.product = newStringAttrFromFmtEncoded(attr)
+			item.product = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 3:
-			item.version = newStringAttrFromFmtEncoded(attr)
+			item.version = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 4:
-			item.update = newStringAttrFromFmtEncoded(attr)
+			item.update = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 5:
-			item.edition = newStringAttrFromFmtEncoded(attr)
+			item.edition = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 6:
-			item.language = newStringAttrFromFmtEncoded(attr)
+			item.language = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 7:
-			item.sw_edition = newStringAttrFromFmtEncoded(attr)
+			item.sw_edition = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 8:
-			item.target_sw = newStringAttrFromFmtEncoded(attr)
+			item.target_sw = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 9:
-			item.target_hw = newStringAttrFromFmtEncoded(attr)
+			item.target_hw = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		case 10:
-			item.other = newStringAttrFromFmtEncoded(attr)
+			item.other = newStringAttrFromFmtEncoded(replaceFromDelim(attr))
 		}
 	}
 
@@ -381,7 +383,6 @@ func (i *Item) SwEdition() StringAttr {
 	return i.sw_edition
 }
 
-
 // SetTargetSw sets target_sw of item.  returns error if s is invalid.
 func (i *Item) SetTargetSw(s StringAttr) error {
 	if !s.IsValid() {
@@ -425,6 +426,14 @@ func (i *Item) SetOther(s StringAttr) error {
 // Other returns other of item.
 func (i *Item) Other() StringAttr {
 	return i.other
+}
+
+func replaceToDelim(str string) string {
+	return strings.Replace(str, "\\:", goCpeOriginalDelim, -1)
+}
+
+func replaceFromDelim(str string) string {
+	return strings.Replace(str, goCpeOriginalDelim, "\\:", -1)
 }
 
 type cpeerr struct {

--- a/naming_test.go
+++ b/naming_test.go
@@ -1,8 +1,9 @@
 package cpe
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // from 5.5 WFN Example @ NISTIR-7695-CPE-Naming
@@ -258,6 +259,17 @@ func TestNewItemFromFmt(t *testing.T) {
 		assert.Equal(t, item.TargetHw(), NewStringAttr("80gb"))
 	}
 
+	item, err = NewItemFromFormattedString(`cpe:2.3:a:xt-commerce:xt\\:commerce:*:*:*:*:*:*:*:*`)
+	assert.Nil(t, err)
+	if item != nil {
+		assert.Equal(t, item.Part(), Application)
+		assert.Equal(t, item.Vendor(), NewStringAttr("xt-commerce"))
+		assert.Equal(t, item.Product(), NewStringAttr("xt:commerce"))
+		assert.Equal(t, item.SwEdition(), NewStringAttr(""))
+		assert.Equal(t, item.TargetSw(), NewStringAttr(""))
+		assert.Equal(t, item.TargetHw(), NewStringAttr(""))
+	}
+
 	// Example1'
 	item, err = NewItemFromFormattedString(`a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*`)
 	assert.Error(t, err)
@@ -265,22 +277,23 @@ func TestNewItemFromFmt(t *testing.T) {
 	// Example1''
 	item, err = NewItemFromFormattedString(`cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*`)
 	assert.Error(t, err)
+
 }
 
 func BenchmarkNewItemFromUri(b *testing.B) {
-	for i:=0; i< b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		NewItemFromUri("cpe:/a:microsoft:internet_explorer:8.0.6001:beta")
 	}
 }
 
 func BenchmarkNewItemFromWfn(b *testing.B) {
-	for i:=0; i< b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		NewItemFromWfn(`wfn:[part="a",vendor="microsoft",product="internet_explorer",version="8\.0\.6001",update="beta",edition=NA]`)
 	}
 }
 
 func BenchmarkNewItemFromFormattedString(b *testing.B) {
-	for i:=0; i< b.N; i++ {
+	for i := 0; i < b.N; i++ {
 		NewItemFromFormattedString(`cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*`)
 	}
 }


### PR DESCRIPTION
Hello. Thank you for a wonderful tool.

I want you to fix only one point. As you know,  `cpe name` may contain escaped colons (ex. `cpe:2.3:a:xt-commerce:xt\\:commerce:*:*:*:*:*:*:*:*` ). 
In that case, splitting with that colon will result in incorrect splitting.
Therefore, I implemented it so that I replace the escaped colons with the original character string, split it, and then restore it.

Finally, the naming_test.go was automatically formatted with fmt of go. sorry..

Check this, please.